### PR TITLE
Serialize `startNotifications` in the promise chain

### DIFF
--- a/src/io/ble-web.js
+++ b/src/io/ble-web.js
@@ -120,7 +120,7 @@ class WebBLE {
                         const dataView = event.target.value;
                         onCharacteristicChanged(uint8ArrayToBase64(new Uint8Array(dataView.buffer)));
                     });
-                characteristic.startNotifications();
+                return characteristic.startNotifications();
             });
     }
 
@@ -138,7 +138,8 @@ class WebBLE {
             .then(service => service.getCharacteristic(characteristicId))
             .then(characteristic => {
                 if (optStartNotifications) {
-                    this.startNotifications(serviceId, characteristicId, onCharacteristicChanged);
+                    return this.startNotifications(serviceId, characteristicId, onCharacteristicChanged)
+                        .then(() => characteristic.readValue());
                 }
                 return characteristic.readValue();
             })


### PR DESCRIPTION
The call to `characteristic.startNotifications()` was never awaited for which caused issues on some devices (especially older phones and tablets with Android 12). Running multiple actions at once could throw errors like "GATT operation failed for unknown reasons".

### Proposed Changes
Await for `startNotifications` (chain it with the existing promises).
In case it would fail, it can be caught.

### Reason for Changes
WebBLE connection issues on some Android 12 devices (in a different project).
